### PR TITLE
Fix subtyping

### DIFF
--- a/chalk/bounding_box.py
+++ b/chalk/bounding_box.py
@@ -80,7 +80,7 @@ class BoundingBox(Transformable):
             max(self.bottom, point.y),
         )
 
-    def apply_transform(self, t: Transform) -> "BoundingBox":
+    def apply_transform(self, t: Transform) -> "BoundingBox":  # type: ignore
         tl = self.tl.apply_transform(t)
         return (
             BoundingBox(tl, tl)

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -214,8 +214,8 @@ class Diagram(tx.Transformable):
         α = y / box.width
         return ApplyTransform(tx.Scale(α, α), self)
 
-    def apply_transform(self, transform: tx.Transform) -> "Diagram":
-        return ApplyTransform(transform, self)
+    def apply_transform(self, t: tx.Transform) -> "Diagram":  # type: ignore
+        return ApplyTransform(t, self)
 
     # def at(self, x: float, y: float) -> "Diagram":
     #     t = tx.Translate(x, y)
@@ -261,7 +261,7 @@ class Diagram(tx.Transformable):
             Style(fill_opacity=0, line_color=Color("red")),
             Ident,
         ).translate(box.center.x, box.center.y)
-        return self + origin  # type: ignore
+        return self + origin
 
     def named(self, name: str) -> "Diagram":
         return ApplyName(name, self)
@@ -285,8 +285,8 @@ class Primitive(Diagram):
     def from_shape(cls, shape: Shape) -> "Primitive":
         return cls(shape, Style.default(), Ident)
 
-    def apply_transform(self, other_transform: tx.Transform) -> "Primitive":
-        new_transform = tx.Compose(other_transform, self.transform)
+    def apply_transform(self, t: tx.Transform) -> "Primitive":  # type: ignore
+        new_transform = tx.Compose(t, self.transform)
         return Primitive(self.shape, self.style, new_transform)
 
     def apply_style(self, other_style: Style) -> "Primitive":

--- a/chalk/point.py
+++ b/chalk/point.py
@@ -10,7 +10,7 @@ class Point(tx.Transformable):
     x: float
     y: float
 
-    def apply_transform(self, t: tx.Transform) -> "Point":
+    def apply_transform(self, t: tx.Transform):  # type: ignore
         new_x, new_y = t().transform_point(self.x, self.y)
         return Point(new_x, new_y)
 
@@ -40,7 +40,7 @@ class Vector(tx.Transformable):
         dy = r * math.sin(angle)
         return cls(dx, dy)
 
-    def apply_transform(self, t: tx.Transform) -> "Vector":
+    def apply_transform(self, t: tx.Transform):  # type:ignore
         new_dx, new_dy = t().transform_point(self.dx, self.dy)
         return Vector(new_dx, new_dy)
 

--- a/chalk/trail.py
+++ b/chalk/trail.py
@@ -28,5 +28,5 @@ class Trail(tx.Transformable):
     def transform(self, t: tx.Transform) -> "Trail":
         return Trail([p.apply_transform(t) for p in self.offsets])
 
-    def apply_transform(self, t: tx.Transform) -> "Trail":
+    def apply_transform(self, t: tx.Transform) -> "Trail":  # type: ignore
         return self.transform(t)

--- a/chalk/transform.py
+++ b/chalk/transform.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import TypeVar
 
 import cairo
 import math
@@ -99,41 +100,44 @@ class Compose(Transform):
         return self.t.to_svg() + " " + self.u.to_svg()
 
 
+TTrans = TypeVar("TTrans", bound="Transformable")
+
+
 class Transformable:
-    def apply_transform(self, t: Transform) -> "Transformable":
+    def apply_transform(self, t: Transform) -> TTrans:
         pass
 
-    def scale(self, α: float) -> "Transformable":
+    def scale(self: TTrans, α: float) -> TTrans:
         return self.apply_transform(Scale(α, α))
 
-    def scale_x(self, α: float) -> "Transformable":
+    def scale_x(self: TTrans, α: float) -> TTrans:
         return self.apply_transform(Scale(α, 1))
 
-    def scale_y(self, α: float) -> "Transformable":
+    def scale_y(self: TTrans, α: float) -> TTrans:
         return self.apply_transform(Scale(1, α))
 
-    def rotate(self, θ: float) -> "Transformable":
+    def rotate(self: TTrans, θ: float) -> TTrans:
         return self.apply_transform(Rotate(θ))
 
-    def rotate_by(self, turns: float) -> "Transformable":
+    def rotate_by(self: TTrans, turns: float) -> TTrans:
         """Rotate by fractions of a circle (turn)."""
         θ = 2 * math.pi * turns
         return self.apply_transform(Rotate(θ))
 
-    def reflect_x(self) -> "Transformable":
+    def reflect_x(self: TTrans) -> TTrans:
         return self.apply_transform(Scale(-1, +1))
 
-    def reflect_y(self) -> "Transformable":
+    def reflect_y(self: TTrans) -> TTrans:
         return self.apply_transform(Scale(+1, -1))
 
-    def shear_x(self, λ: float) -> "Transformable":
+    def shear_x(self: TTrans, λ: float) -> TTrans:
         return self.apply_transform(ShearX(λ))
 
-    def shear_y(self, λ: float) -> "Transformable":
+    def shear_y(self: TTrans, λ: float) -> TTrans:
         return self.apply_transform(ShearY(λ))
 
-    def translate(self, dx: float, dy: float) -> "Transformable":
+    def translate(self: TTrans, dx: float, dy: float) -> TTrans:
         return self.apply_transform(Translate(dx, dy))
 
-    def translate_by(self, vector) -> "Transformable":  # type: ignore
+    def translate_by(self: TTrans, vector) -> TTrans:  # type: ignore
         return self.apply_transform(Translate(vector.dx, vector.dy))


### PR DESCRIPTION
Despite our best wishes we are not in haskell. Typing is still kind of hacky in python. 

This PR hides the apply_transform and ensure that the user facing transformable keeps the right types. 