### PR TITLE
Make `Path` an instance of `Transformable` 

### DIFF
--- a/chalk/__init__.py
+++ b/chalk/__init__.py
@@ -27,8 +27,7 @@ def empty() -> Diagram:
 def make_path(
     coords: List[Tuple[float, float]], arrow: bool = False
 ) -> Diagram:
-    points = [Point(x, y) for x, y in coords]
-    return Primitive.from_shape(Path(points, arrow))
+    return Primitive.from_shape(Path.from_list_of_tuples(coords, arrow))
 
 
 def circle(radius: float) -> Diagram:
@@ -81,31 +80,19 @@ def arc_between(
 
 
 def polygon(sides: int, radius: float, rotation: float = 0) -> Diagram:
-    coords = []
-    n = sides + 1
-    for s in range(n):
-        # Rotate to align with x axis.
-        t = 2.0 * math.pi * s / sides + (math.pi / 2 * sides) + rotation
-        coords.append((radius * math.cos(t), radius * math.sin(t)))
-    return make_path(coords)
-
-
-def place_at(
-    diagrams: Iterable[Diagram], points: List[Tuple[float, float]]
-) -> Diagram:
-    return concat(d.translate(x, y) for d, (x, y) in zip(diagrams, points))
-
-
-def hrule(length: float) -> Diagram:
-    return make_path([(-length / 2, 0), (length / 2, 0)])
-
-
-def vrule(length: float) -> Diagram:
-    return make_path([(0, -length / 2), (0, length / 2)])
+    return Primitive.from_shape(Path.polygon(sides, radius, rotation))
 
 
 def regular_polygon(sides: int, side_length: float) -> Diagram:
-    return polygon(sides, side_length / (2 * math.sin(math.pi / sides)))
+    return Primitive.from_shape(Path.regular_polygon(sides, side_length))
+
+
+def hrule(length: float) -> Diagram:
+    return Primitive.from_shape(Path.hrule(length))
+
+
+def vrule(length: float) -> Diagram:
+    return Primitive.from_shape(Path.vrule(length))
 
 
 def triangle(width: float) -> Diagram:
@@ -140,6 +127,16 @@ def atop(diagram1: Diagram, diagram2: Diagram) -> Diagram:
 
 def beside(diagram1: Diagram, diagram2: Diagram) -> Diagram:
     return diagram1.beside(diagram2)
+
+
+def place_at(
+    diagrams: Iterable[Diagram], points: List[Tuple[float, float]]
+) -> Diagram:
+    return concat(d.translate(x, y) for d, (x, y) in zip(diagrams, points))
+
+
+def place_on_path(diagrams: Iterable[Diagram], path: Path) -> Diagram:
+    return concat(d.translate(p.x, p.y) for d, p in zip(diagrams, path.points))
 
 
 def above(diagram1: Diagram, diagram2: Diagram) -> Diagram:

--- a/chalk/trail.py
+++ b/chalk/trail.py
@@ -1,7 +1,7 @@
-from typing import List, Any
+from typing import List
 
 from chalk.core import Primitive
-from chalk.point import Point, Vector
+from chalk.point import Point, Vector, ORIGIN
 from chalk.shape import Path
 from chalk import transform as tx
 
@@ -13,20 +13,27 @@ class Trail(tx.Transformable):
     def __add__(self, other: "Trail") -> "Trail":
         return Trail(self.offsets + other.offsets)
 
-    @staticmethod
-    def from_path(path: Any) -> "Trail":
-        pts = path.shape.points
+    @classmethod
+    def from_path(cls, path: Path) -> "Trail":
+        pts = path.points
         offsets = [t - s for s, t in zip(pts, pts[1:])]
-        return Trail(offsets)
+        return cls(offsets)
 
-    def stroke(self) -> Primitive:
-        points = [Point(0, 0)]
+    def to_path(self, origin: Point = ORIGIN) -> Path:
+        points = [origin]
         for s in self.offsets:
             points.append(points[-1] + s)
-        return Primitive.from_shape(Path(points))
+        return Path(points)
+
+    def stroke(self) -> Primitive:
+        return Primitive.from_shape(self.to_path())
 
     def transform(self, t: tx.Transform) -> "Trail":
         return Trail([p.apply_transform(t) for p in self.offsets])
 
     def apply_transform(self, t: tx.Transform) -> "Trail":  # type: ignore
         return self.transform(t)
+
+
+unit_x = Trail([Vector(1, 0)])
+unit_y = Trail([Vector(0, 1)])

--- a/examples/hilbert.py
+++ b/examples/hilbert.py
@@ -1,5 +1,6 @@
 from chalk import *
 from chalk.transform import *
+from chalk.trail import unit_x, unit_y
 
 
 # Draw a space filling Hilbert curve
@@ -8,9 +9,9 @@ def hilbert(n):
     def hilbert2(m): return hilbert(m).rotate(-math.pi / 2)
     if n == 0: return Trail([])
     h, h2 = hilbert(n -1), hilbert2(n-1)
-    return (h2.reflect_y() + Trail.from_path(vrule(1))
-            + h + Trail.from_path(hrule(1))
-            + h + Trail.from_path(vrule(-1))
+    return (h2.reflect_y() + unit_y
+            + h + unit_x
+            + h + unit_y.reflect_y()
             + h2.reflect_x())
 
 d = hilbert(5).stroke().line_width(0.05)

--- a/examples/koch.py
+++ b/examples/koch.py
@@ -1,10 +1,11 @@
 from chalk import *
 from chalk.transform import *
+from chalk.trail import unit_x
 
 
 def koch(n):
     if n == 0:
-        return Trail.from_path(hrule(5))
+        return unit_x.scale_x(5)
     else:
         return (
             koch(n - 1).scale(1 / 3)


### PR DESCRIPTION
Allows the placement on diagrams on a _transformed_ path. For example

```python
from colour import Color
from chalk import *
from chalk.shape import Path

green = Color("green")
nodes = [circle(0.2).fill_color(green) for _ in range(6)]
path = Path.polygon(6, 1).shear_x(0.5)
place_on_path(nodes, path)
```

produces 

![image](https://user-images.githubusercontent.com/819256/169654447-c43f4736-81db-4027-abef-eadacf9697ad.png)

Other changes include:

- refactored the definition of some shapes (`hrule`, `vrule`, `polygon`) as `Path` (so they can be used for placement)
- updated the `Trail.from_path` constructor to take at input a `Path` instead of a `Diagram`-wrapped `Path`,
since the latter resolves the transformation at rendering and might lead unexpected results (e.g., `Trail.from_path(polygon(6, 1).shear_x(0.5))` wouldn't have taken the transformation into account).