### PR TITLE
Adding diagram display utilities to `chalk`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         sudo apt-get install libcairo2-dev pdf2svg texlive texlive-science texlive-latex-recommended texlive-latex-extra
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+        pip install -r requirements/dev.txt
         pip install -U pip setuptools wheel
         make install
     - name: Format with black

--- a/.github/workflows/mkdocs-publish-ghpages.yml
+++ b/.github/workflows/mkdocs-publish-ghpages.yml
@@ -47,5 +47,6 @@ jobs:
           echo "Current Git Branch: ${USER_SPECIFIED_BRANCH}"
 
           # Begin Deploying MkDocs
+          make pregendocs
           mkdocs gh-deploy --force
           mkdocs --version

--- a/.github/workflows/mkdocs-publish-ghpages.yml
+++ b/.github/workflows/mkdocs-publish-ghpages.yml
@@ -1,0 +1,51 @@
+name: "MkDocs Publish Docs on GitHub Pages CI"
+on:
+  # Manually trigger workflow
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Build MkDocs from Branch (Optional)
+        required: false
+  # Trigger when a push happens
+  # to select branches.
+  push:
+    branches:
+      - master
+      - main
+
+env:
+  PYTHON_VERSION: "3.7"
+  USER_SPECIFIED_BRANCH: ${{ github.event.inputs.branch }}
+  REPO_OWNER: ${{ github.repository_owner }} # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python runtime
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python dependencies for MkDocs
+        run: pip install -r requirements/docs.txt
+
+      - name: Deploy documentation
+        env:
+          FONTAWESOME_KIT: ${{ secrets.FONTAWESOME_KIT }}
+        run: |
+          # Check if user-provided branch exists
+          # then switch to that branch.
+          if [[ -z $(git branch --list "${{ env.USER_SPECIFIED_BRANCH }}") ]]; \
+            then (\
+              echo "Switching to branch: ${{ env.USER_SPECIFIED_BRANCH }}" && \
+              git checkout ${{ env.USER_SPECIFIED_BRANCH }} \
+            ); else USER_SPECIFIED_BRANCH=${GITHUB_REF##*/} ; fi && \
+          echo "Current Git Branch: ${USER_SPECIFIED_BRANCH}"
+
+          # Begin Deploying MkDocs
+          mkdocs gh-deploy --force
+          mkdocs --version

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,11 @@ TESTS_DIR := "tests"
 # % success threshold is under the following value
 INTERROGATE_FAIL_UNDER := 0  # ideally this should be 100
 
-# Specify paths of requirements.txt and dev_requirements.txt
-REQ_FILE := "requirements.txt"
-DEV_REQ_FILE := "requirements-dev.txt"
+# Specify paths of various dependency files
+REQ_FOLDER := "requirements"
+REQ_FILE := "requirements.txt"  # requirements.txt
+DEV_REQ_FILE := "dev.txt"  # requirements-dev.txt
+DOCS_REQ_FILE := "docs.txt"  # requirements-docs.txt
 
 ####------------------------------------------------------------####
 
@@ -127,7 +129,10 @@ install: clean
 
 installextras: install
 	@echo "📀 Installing $(PACKAGE_NAME) extra-dependencies from PyPI ... ⏳"
-	if [ -f $(DEV_REQ_FILE) ]; then python -m pip install -r $(DEV_REQ_FILE); fi
+	@echo "Installing from: $(DEV_REQ_FILE) ... ⏳"
+	if [ -f $(REQ_FOLDER)/$(DEV_REQ_FILE) ]; then python -m pip install -r $(REQ_FOLDER)/$(DEV_REQ_FILE); fi
+	@echo "Installing from: $(DOCS_REQ_FILE) ... ⏳"
+	if [ -f $(REQ_FOLDER)/$(DOCS_REQ_FILE) ]; then python -m pip install -r $(REQ_FOLDER)/$(DOCS_REQ_FILE); fi
 
 ## Install from test.pypi.org
 #

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ installextras: install
 	@echo "Installing from: $(DEV_REQ_FILE) ... ⏳"
 	if [ -f $(REQ_FOLDER)/$(DEV_REQ_FILE) ]; then python -m pip install -r $(REQ_FOLDER)/$(DEV_REQ_FILE); fi
 	@echo "Installing from: $(DOCS_REQ_FILE) ... ⏳"
-	if [ -f $(REQ_FOLDER)/$(DOCS_REQ_FILE) ]; then python -m pip install -r $(REQ_FOLDER)/$(DOCS_REQ_FILE); fi
+	@if [ -f $(REQ_FOLDER)/$(DOCS_REQ_FILE) ]; then python -m pip install -r $(REQ_FOLDER)/$(DOCS_REQ_FILE); fi
 
 ## Install from test.pypi.org
 #

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 .PHONY: install installextras pipinstalltest
 
 # documentation
-.PHONY: gendocs
+.PHONY: pregendocs gendocs postgendocs gendocsall
 
 # generate examples
 .PHONY: intro squares hanoi escher_square lattice lenet logo \
@@ -161,9 +161,20 @@ pipinstalltest:
 
 ### Generate documentation with MkDocs
 
+pregendocs:
+	@echo "make a copy of doc folder inside docs ... ⏳"
+	cp -rf doc docs/doc
+
 gendocs:
 	@echo "🔥 Generate documentation with MkDocs ... ⏳"
+	# generate documentation
 	mkdocs serve
+
+postgendocs:
+	#echo "Cleanup docs... ⏳"
+	rm -rf docs/doc
+
+gendocsall: pregendocs gendocs postgendocs
 
 ####------------------------------------------------------------####
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@
 # installation
 .PHONY: install installextras pipinstalltest
 
+# documentation
+.PHONY: gendocs
+
 # generate examples
 .PHONY: intro squares hanoi escher_square lattice lenet logo \
 		hilbert koch tensor latex hex_variation images
@@ -153,6 +156,14 @@ pipinstalltest:
 	#      If no version is specified, the latest version is installed from TestPyPI.
 	@if [ $(VERSION) ]; then $(PIPINSTALL_PYPITEST) $(PACKAGE_NAME)==$(VERSION); else $(PIPINSTALL_PYPITEST) $(PACKAGE_NAME); fi;
 
+
+####------------------------------------------------------------####
+
+### Generate documentation with MkDocs
+
+gendocs:
+	@echo "🔥 Generate documentation with MkDocs ... ⏳"
+	mkdocs serve
 
 ####------------------------------------------------------------####
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+<!--- BADGES: START --->
+[![GitHub - License](https://img.shields.io/github/license/danoneata/chalk?logo=github&style=flat&color=green)][#github-license]
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/chalk-diagrams?logo=pypi&style=flat&color=blue)][#pypi-package]
+[![PyPI - Package Version](https://img.shields.io/pypi/v/chalk-diagrams?logo=pypi&style=flat&color=orange)][#pypi-package]
+[![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/chalk-diagrams?logo=anaconda&style=flat)][#conda-forge-package]
+[![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/chalk-diagrams?logo=anaconda&style=flat&color=orange)][#conda-forge-package]
+[![Docs - GitHub.io](https://img.shields.io/static/v1?logo=github&style=flat&color=pink&label=docs&message=chalk-diagrams)][#docs-package]
+
+[#github-license]: https://github.com/danoneata/chalk/blob/master/LICENSE
+[#pypi-package]: https://pypi.org/project/chalk-diagrams/
+[#conda-forge-package]: https://anaconda.org/conda-forge/chalk-diagrams
+[#docs-package]: https://danoneata.github.io/chalk/
+<!--- BADGES: END --->
+
+
 <p align="center"><img src="https://raw.githubusercontent.com/danoneata/chalk/master/examples/output/logo-sm.png" width=300></p>
 
 Chalk is a declarative drawing library built on top of [PyCairo](https://pycairo.readthedocs.io).
@@ -11,22 +26,36 @@ Jeremy Gibbons's lecture notes on [Functional Programming for Domain−Specific 
 ## Installation
 
 The library is available on PyPI as `chalk-diagrams` and can be installed with `pip`:
+
 ```bash
 pip install chalk-diagrams
 ```
+
 On Debian (or Colab) you will need to install Cairo
+
 ```bash
 sudo apt-get install libcairo2-dev
 ```
 
 If you want to use the LaTeX extension, run:
+
 ```bash
 pip install chalk-diagrams[latex]
 ```
+
 For the LaTeX extension you might need to install `pdf2svg` and `texlive`;
 on Debian these dependencies can be installed as follows:
+
 ```bash
 sudo apt-get install pdf2svg texlive texlive-science texlive-latex-recommended texlive-latex-extra
+```
+
+**Installation with Conda**
+
+You can install the library with **conda** from `conda-forge` channel.
+
+```powershell
+conda install -c conda-forge chalk-diagrams
 ```
 
 ## Overview
@@ -143,4 +172,3 @@ python examples/squares.py
 - [Alexander Rush](http://rush-nlp.com/)
 
 Special thanks to [Ionuț G. Stan](http://igstan.ro/) for providing many useful insights and comments!
-

--- a/chalk/__init__.py
+++ b/chalk/__init__.py
@@ -73,7 +73,7 @@ def arc_between(
         shape: Diagram = make_path([(0, 0), (d, 0)])
     else:
         # Determine the arc's angle θ and its radius r
-        θ = math.acos((d ** 2 - 4 * h ** 2) / (d ** 2 + 4 * h ** 2))
+        θ = math.acos((d**2 - 4 * h**2) / (d**2 + 4 * h**2))
         r = d / (2 * math.sin(θ))
 
         if height > 0:

--- a/chalk/bounding_box.py
+++ b/chalk/bounding_box.py
@@ -35,6 +35,12 @@ class BoundingBox(Transformable):
     def empty(cls) -> "BoundingBox":
         """Returns an empty bounding box.
 
+        The bounding box will have the following
+        specifications:
+
+        - top-left corner: `(0,0)`
+        - bottom-right corner: `(0,0)`
+
         Returns:
             BoundingBox: A bounding box object.
         """

--- a/chalk/bounding_box.py
+++ b/chalk/bounding_box.py
@@ -6,6 +6,8 @@ from chalk.transform import Transform, Transformable
 
 @dataclass
 class BoundingBox(Transformable):
+    """BoundingBox class."""
+
     tl: Point
     br: Point
 
@@ -13,23 +15,70 @@ class BoundingBox(Transformable):
     def from_limits(
         cls, left: float, top: float, right: float, bottom: float
     ) -> "BoundingBox":
+        """Returns a bounding box from limits
+        (``left``, ``top``, ``right``, ``bottom``).
+
+        Args:
+            left (float): Position of left edge.
+            top (float): Position of top edge.
+            right (float): Position of right edge.
+            bottom (float): Position of bottom edge.
+
+        Returns:
+            BoundingBox: A bounding box object.
+        """
         tl = Point(left, top)
         br = Point(right, bottom)
         return cls(tl, br)
 
     @classmethod
     def empty(cls) -> "BoundingBox":
+        """Returns an empty bounding box.
+
+        Returns:
+            BoundingBox: A bounding box object.
+        """
         return cls(ORIGIN, ORIGIN)
 
     @property
     def tr(self) -> Point:
+        """Returns the position of the top-right corner
+        of the bounding box.
+
+        Returns:
+            Point: A point object (``chalk.point.Point``).
+        """
         return Point(self.right, self.top)
 
     @property
     def bl(self) -> Point:
+        """Returns the position of the bottom-left corner
+        of the bounding box.
+
+        Returns:
+            Point: A point object (``chalk.point.Point``).
+        """
         return Point(self.left, self.bottom)
 
     def cardinal(self, dir: str) -> Point:
+        """Returns the position of and edge or a corner of the bounding
+        box based on a labeled direction (``dir``).
+
+        Args:
+            dir (str): Direction of the edge or the corner.
+                Options are:
+                  - ``N``: North        | edge
+                  - ``S``: South        | edge
+                  - ``W``: West         | edge
+                  - ``E``: East         | edge
+                  - ``NW``: North West  | corner
+                  - ``NE``: North East  | corner
+                  - ``SW``: South West  | corner
+                  - ``SE``: South East  | corner
+
+        Returns:
+            Point: A point object (``chalk.point.Point``).
+        """
         return {
             "N": Point(self.left + self.width / 2, self.top),
             "S": Point(self.left + self.width / 2, self.bottom),
@@ -44,35 +93,83 @@ class BoundingBox(Transformable):
 
     @property
     def width(self) -> float:
+        """Returns width of the bounding box.
+
+        Returns:
+            float: The width.
+        """
         return self.br.x - self.tl.x
 
     @property
     def height(self) -> float:
+        """Returns height of the bounding box.
+
+        Returns:
+            float: The height.
+        """
         return self.br.y - self.tl.y
 
     @property
     def left(self) -> float:
+        """Returns ``x`` position of the left-edge
+        of the bounding box.
+
+        Returns:
+            float: The x-coordinate of the left edge.
+        """
         return self.tl.x
 
     @property
     def top(self) -> float:
+        """Returns ``y`` position of the top-edge
+        of the bounding box.
+
+        Returns:
+            float: The y-coordinate of the top edge.
+        """
         return self.tl.y
 
     @property
     def right(self) -> float:
+        """Returns ``x`` position of the right-edge
+        of the bounding box.
+
+        Returns:
+            float: The x-coordinate of the right edge.
+        """
         return self.br.x
 
     @property
     def bottom(self) -> float:
+        """Returns ``y`` position of the bottom-edge
+        of the bounding box.
+
+        Returns:
+            float: The y-coordinate of the bottom edge.
+        """
         return self.br.y
 
     @property
     def center(self) -> Point:
+        """Returns position of the center
+        of the bounding box.
+
+        Returns:
+            Point: A point object (``chalk.point.Point``).
+        """
         x = (self.left + self.right) / 2
         y = (self.top + self.bottom) / 2
         return Point(x, y)
 
     def enclose(self, point: Point) -> "BoundingBox":
+        """Return a bounding box that encloses a given point.
+
+        Args:
+            point (Point): A point object (``chalk.point.Point``).
+
+        Returns:
+            BoundingBox: A bounding box object.
+        """
         return BoundingBox.from_limits(
             min(self.left, point.x),
             min(self.top, point.y),
@@ -81,6 +178,14 @@ class BoundingBox(Transformable):
         )
 
     def apply_transform(self, t: Transform) -> "BoundingBox":  # type: ignore
+        """Applies a transformation to the bounding box.
+
+        Args:
+            t (Transform): A transform object (``chalk.transform.Transform``)
+
+        Returns:
+            BoundingBox: A bounding box object.
+        """
         tl = self.tl.apply_transform(t)
         return (
             BoundingBox(tl, tl)
@@ -90,6 +195,19 @@ class BoundingBox(Transformable):
         )
 
     def union(self, other: "BoundingBox") -> "BoundingBox":
+        """Returns the union (merged bounding box) of this
+        bounding box with another one.
+
+        For two bounding boxes, ``a`` and ``b``, ``a.union(b)``
+        will return another bounding box that minimally-contains
+        both bounding boxes.
+
+        Args:
+            other (BoundingBox): Another bounding box object.
+
+        Returns:
+            BoundingBox: A bounding box object.
+        """
         left = min(self.left, other.left)
         top = min(self.top, other.top)
         right = max(self.right, other.right)

--- a/chalk/bounding_box.py
+++ b/chalk/bounding_box.py
@@ -72,18 +72,25 @@ class BoundingBox(Transformable):
 
         Args:
             dir (str): Direction of the edge or the corner.
-                Options are:
-                  - ``N``: North        | edge
-                  - ``S``: South        | edge
-                  - ``W``: West         | edge
-                  - ``E``: East         | edge
-                  - ``NW``: North West  | corner
-                  - ``NE``: North East  | corner
-                  - ``SW``: South West  | corner
-                  - ``SE``: South East  | corner
+
+        Choose `dir` from the following table.
+
+        Click to expand:
+
+            | `dir`  |   Directon   |  Type  |
+            |:-------|:-------------|:------:|
+            | ``N``  | North        | edge   |
+            | ``S``  | South        | edge   |
+            | ``W``  | West         | edge   |
+            | ``E``  | East         | edge   |
+            | ``NW`` | North West   | corner |
+            | ``NE`` | North East   | corner |
+            | ``SW`` | South West   | corner |
+            | ``SE`` | South East   | corner |
 
         Returns:
             Point: A point object (``chalk.point.Point``).
+
         """
         return {
             "N": Point(self.left + self.width / 2, self.top),

--- a/chalk/bounding_box.py
+++ b/chalk/bounding_box.py
@@ -52,7 +52,7 @@ class BoundingBox(Transformable):
         of the bounding box.
 
         Returns:
-            Point: A point object (``chalk.point.Point``).
+            Point: A point object.
         """
         return Point(self.right, self.top)
 
@@ -62,12 +62,12 @@ class BoundingBox(Transformable):
         of the bounding box.
 
         Returns:
-            Point: A point object (``chalk.point.Point``).
+            Point: A point object.
         """
         return Point(self.left, self.bottom)
 
     def cardinal(self, dir: str) -> Point:
-        """Returns the position of and edge or a corner of the bounding
+        """Returns the position of an edge or a corner of the bounding
         box based on a labeled direction (``dir``).
 
         Args:
@@ -89,7 +89,7 @@ class BoundingBox(Transformable):
             | ``SE`` | South East   | corner |
 
         Returns:
-            Point: A point object (``chalk.point.Point``).
+            Point: A point object.
 
         """
         return {
@@ -168,7 +168,7 @@ class BoundingBox(Transformable):
         of the bounding box.
 
         Returns:
-            Point: A point object (``chalk.point.Point``).
+            Point: A point object.
         """
         x = (self.left + self.right) / 2
         y = (self.top + self.bottom) / 2
@@ -178,7 +178,7 @@ class BoundingBox(Transformable):
         """Return a bounding box that encloses a given point.
 
         Args:
-            point (Point): A point object (``chalk.point.Point``).
+            point (Point): A point object.
 
         Returns:
             BoundingBox: A bounding box object.
@@ -194,7 +194,7 @@ class BoundingBox(Transformable):
         """Applies a transformation to the bounding box.
 
         Args:
-            t (Transform): A transform object (``chalk.transform.Transform``)
+            t (Transform): A transform object.
 
         Returns:
             BoundingBox: A bounding box object.

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -12,6 +12,7 @@ from colour import Color
 from chalk.bounding_box import BoundingBox
 from chalk.shape import Shape, Circle, Rectangle
 from chalk.style import Style
+from chalk.utils import imgen
 from chalk import transform as tx
 
 
@@ -30,9 +31,31 @@ class Diagram(tx.Transformable):
         """
         raise NotImplementedError
 
+    def display(self, height: int=64, verbose: bool=True, **kwargs: Any) -> None:
+        """Display the diagram using the default renderer.
+
+        Note: see ``chalk.utils.imgen`` for details on the keyword arguments.
+        """
+        # update kwargs with defaults and user-specified values
+        kwargs.update({"height": height})
+        kwargs.update({"verbose": verbose})
+        kwargs.update({"dirpath": None})
+        kwargs.update({"wait": kwargs.get("wait", 2)})
+        # render and display the diagram
+        imgen(self, **kwargs)
+
     def render(
         self, path: str, height: int = 128, width: Optional[int] = None
     ) -> None:
+        """Render the diagram to a PNG file.
+
+        Args:
+            path (str): Path of the .png file.
+            height (int, optional): Height of the rendered image.
+                                    Defaults to 128.
+            width (Optional[int], optional): Width of the rendered image.
+                                             Defaults to None.
+        """
         pad = 0.05
         box = self.get_bounding_box()
 
@@ -70,7 +93,15 @@ class Diagram(tx.Transformable):
     def render_svg(
         self, path: str, height: int = 128, width: Optional[int] = None
     ) -> None:
+        """Render the diagram to an SVG file.
 
+        Args:
+            path (str): Path of the .svg file.
+            height (int, optional): Height of the rendered image.
+                                    Defaults to 128.
+            width (Optional[int], optional): Width of the rendered image.
+                                             Defaults to None.
+        """
         pad = 0.05
         box = self.get_bounding_box()
 

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -42,7 +42,7 @@ class Diagram(tx.Transformable):
         kwargs.update({"height": height})
         kwargs.update({"verbose": verbose})
         kwargs.update({"dirpath": None})
-        kwargs.update({"wait": kwargs.get("wait", 2)})
+        kwargs.update({"wait": kwargs.get("wait", 1)})
         # render and display the diagram
         imgen(self, **kwargs)
 

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -32,7 +32,7 @@ class Diagram(tx.Transformable):
         raise NotImplementedError
 
     def display(
-        self, height: int = 64, verbose: bool = True, **kwargs: Any
+        self, height: int = 256, verbose: bool = True, **kwargs: Any
     ) -> None:
         """Display the diagram using the default renderer.
 

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -22,7 +22,7 @@ Ident = tx.Identity()
 
 @dataclass
 class Diagram(tx.Transformable):
-    """Diagram class (``chalk.core.Diagram``)."""
+    """Diagram class."""
 
     def get_bounding_box(self, t: tx.Transform = Ident) -> BoundingBox:
         """Get the bounding box of a diagram."""
@@ -472,7 +472,7 @@ class Diagram(tx.Transformable):
         """Apply specified fill-color to the diagram.
 
         Args:
-            color (float): A color (``colour.Color``).
+            color (Color): A color object.
 
         Returns:
             Diagram: A diagram object.
@@ -595,7 +595,7 @@ class Primitive(Diagram):
         """Create and return a primitive from a shape.
 
         Args:
-            shape (Shape): A shape object (``chalk.shape.Shape``)
+            shape (Shape): A shape object.
 
         Returns:
             Primitive: A primitive object.
@@ -606,7 +606,7 @@ class Primitive(Diagram):
         """Applies a transform and returns a primitive.
 
         Args:
-            t (Transform): A transform object (``chalk.transform.Transform``)
+            t (Transform): A transform object.
 
         Returns:
             Primitive: A primitive object.
@@ -618,7 +618,7 @@ class Primitive(Diagram):
         """Applies a style and returns a primitive.
 
         Args:
-            other_style (Style): A style object (``chalk.style.Style``)
+            other_style (Style): A style object.
 
         Returns:
             Primitive: A primitive object.
@@ -631,11 +631,11 @@ class Primitive(Diagram):
         """Apply a transform and return a bounding box.
 
         Args:
-            t (Transform): A transform object (``chalk.transform.Transform``)
+            t (Transform): A transform object
                            Defaults to Ident.
 
         Returns:
-            BoundingBox: A bounding box object (``chalk.BoundingBox``)
+            BoundingBox: A bounding box object.
         """
         new_transform = tx.Compose(t, self.transform)
         return self.shape.get_bounding_box().apply_transform(new_transform)
@@ -644,7 +644,7 @@ class Primitive(Diagram):
         """Returns a list of primitives.
 
         Args:
-            t (Transform): A transform object (``chalk.transform.Transform``)
+            t (Transform): A transform object
                            Defaults to Ident.
 
         Returns:

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -31,7 +31,9 @@ class Diagram(tx.Transformable):
         """
         raise NotImplementedError
 
-    def display(self, height: int=64, verbose: bool=True, **kwargs: Any) -> None:
+    def display(
+        self, height: int = 64, verbose: bool = True, **kwargs: Any
+    ) -> None:
         """Display the diagram using the default renderer.
 
         Note: see ``chalk.utils.imgen`` for details on the keyword arguments.
@@ -142,6 +144,19 @@ class Diagram(tx.Transformable):
         return svg
 
     def atop(self, other: "Diagram") -> "Diagram":
+        """Given to diagrams ``a`` and ``b``, ``a.atop(b)``
+        places ``a`` and ``b`` such that none of them move.
+        This is equivalent to **union** operation of two the
+        shapes.
+
+        💡 ``a.atop(b)`` is equivalent to ``a + b``.
+
+        Args:
+            other (Diagram): Another diagram object.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box1 = self.get_bounding_box()
         box2 = other.get_bounding_box()
         new_box = box1.union(box2)
@@ -150,6 +165,18 @@ class Diagram(tx.Transformable):
     __add__ = atop
 
     def beside(self, other: "Diagram") -> "Diagram":
+        """Given to diagrams ``a`` and ``b``, ``a.beside(b)``
+        places ``b`` on the right side of ``a``. This moves
+        ``b`` up to touch ``a``.
+
+        💡 ``a.beside(b)`` is equivalent to ``a | b``.
+
+        Args:
+            other (Diagram): Another diagram object.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box1 = self.get_bounding_box()
         box2 = other.get_bounding_box()
         dx = box1.right - box2.left
@@ -160,6 +187,18 @@ class Diagram(tx.Transformable):
     __or__ = beside
 
     def above(self, other: "Diagram") -> "Diagram":
+        """Given to diagrams ``a`` and ``b``, ``a.above(b)``
+        places ``b`` under ``a``. This moves ``b`` up to
+        touch ``a``.
+
+        💡 ``a.above(b)`` is equivalent to ``a / b``.
+
+        Args:
+            other (Diagram): Another diagram object.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box1 = self.get_bounding_box()
         box2 = other.get_bounding_box()
         dy = box1.bottom - box2.top
@@ -170,6 +209,18 @@ class Diagram(tx.Transformable):
     __truediv__ = above
 
     def above2(self, other: "Diagram") -> "Diagram":
+        """Given to diagrams ``a`` and ``b``, ``a.above2(b)``
+        places ``a`` on top of ``b``. This moves ``a`` down to
+        touch ``b``.
+
+        💡 ``a.above2(b)`` is equivalent to ``a // b``.
+
+        Args:
+            other (Diagram): Another diagram object.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box1 = self.get_bounding_box()
         box2 = other.get_bounding_box()
         dy = box1.bottom - box2.top
@@ -180,44 +231,99 @@ class Diagram(tx.Transformable):
     __floordiv__ = above2
 
     def center_xy(self) -> "Diagram":
+        """Center a diagram.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         c = box.center
         t = tx.Translate(-c.x, -c.y)
         return ApplyTransform(t, self)
 
     def align_t(self) -> "Diagram":
+        """Align a diagram with its top edge.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         t = tx.Translate(0, -box.top)
         return ApplyTransform(t, self)
 
     def align_b(self) -> "Diagram":
+        """Align a diagram with its bottom edge.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         t = tx.Translate(0, -box.bottom)
         return ApplyTransform(t, self)
 
     def align_r(self) -> "Diagram":
+        """Align a diagram with its right edge.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         t = tx.Translate(-box.right, 0)
         return ApplyTransform(t, self)
 
     def align_l(self) -> "Diagram":
+        """Align a diagram with its left edge.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         t = tx.Translate(-box.left, 0)
         return ApplyTransform(t, self)
 
     def align_tl(self) -> "Diagram":
+        """Align a diagram with its top-left edges.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return self.align_t().align_l()
 
     def align_br(self) -> "Diagram":
+        """Align a diagram with its bottom-right edges.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return self.align_b().align_r()
 
     def align_tr(self) -> "Diagram":
+        """Align a diagram with its top-right edges.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return self.align_t().align_r()
 
     def align_bl(self) -> "Diagram":
+        """Align a diagram with its bottom-left edges.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return self.align_b().align_l()
 
     def pad_l(self, extra: float) -> "Diagram":
+        """Add outward directed left-side padding for
+        a diagram. This padding is applied **only** on
+        the **left** side.
+
+        Args:
+            extra (float): Amount of padding to add.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         new_box = BoundingBox.from_limits(
             box.tl.x - extra, box.tl.y, box.br.x, box.br.y
@@ -225,6 +331,16 @@ class Diagram(tx.Transformable):
         return Compose(new_box, self, Empty())
 
     def pad_t(self, extra: float) -> "Diagram":
+        """Add outward directed top-side padding for
+        a diagram. This padding is applied **only** on
+        the **top** side.
+
+        Args:
+            extra (float): Amount of padding to add.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         new_box = BoundingBox.from_limits(
             box.tl.x, box.tl.y - extra, box.br.x, box.br.y
@@ -232,6 +348,16 @@ class Diagram(tx.Transformable):
         return Compose(new_box, self, Empty())
 
     def pad_r(self, extra: float) -> "Diagram":
+        """Add outward directed right-side padding for
+        a diagram. This padding is applied **only** on
+        the **right** side.
+
+        Args:
+            extra (float): Amount of padding to add.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         new_box = BoundingBox.from_limits(
             box.tl.x, box.tl.y, box.br.x + extra, box.br.y
@@ -239,6 +365,16 @@ class Diagram(tx.Transformable):
         return Compose(new_box, self, Empty())
 
     def pad_b(self, extra: float) -> "Diagram":
+        """Add outward directed bottom-side padding for
+        a diagram. This padding is applied **only** on
+        the **bottom** side.
+
+        Args:
+            extra (float): Amount of padding to add.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         new_box = BoundingBox.from_limits(
             box.tl.x, box.tl.y, box.br.x, box.br.y + extra
@@ -246,6 +382,15 @@ class Diagram(tx.Transformable):
         return Compose(new_box, self, Empty())
 
     def pad(self, extra: float) -> "Diagram":
+        """Add outward directed padding for a diagram.
+        This padding is applied uniformly on all sides.
+
+        Args:
+            extra (float): Amount of padding to add.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         new_box = BoundingBox.from_limits(
             box.tl.x - extra,
@@ -256,16 +401,40 @@ class Diagram(tx.Transformable):
         return Compose(new_box, self, Empty())
 
     def scale_uniform_to_x(self, x: float) -> "Diagram":
+        """Apply uniform scaling along the x-axis.
+
+        Args:
+            x (float): Amount of scaling along the x-axis.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         α = x / box.width
         return ApplyTransform(tx.Scale(α, α), self)
 
     def scale_uniform_to_y(self, y: float) -> "Diagram":
+        """Apply uniform scaling along the y-axis.
+
+        Args:
+            y (float): Amount of scaling along the y-axis.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         α = y / box.height
         return ApplyTransform(tx.Scale(α, α), self)
 
     def apply_transform(self, t: tx.Transform) -> "Diagram":  # type: ignore
+        """Apply a transformation.
+
+        Args:
+            t (tx.Transform): A transformation.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return ApplyTransform(t, self)
 
     # def at(self, x: float, y: float) -> "Diagram":
@@ -273,20 +442,65 @@ class Diagram(tx.Transformable):
     #     return ApplyTransform(t, self.center_xy())
 
     def line_width(self, width: float) -> "Diagram":
+        """Apply specified line-width to the edge of
+        the diagram.
+
+        Args:
+            width (float): Amount of width.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return ApplyStyle(Style(line_width=width), self)
 
     def line_color(self, color: Color) -> "Diagram":
+        """Apply specified line-color to the edge of
+        the diagram.
+
+        Args:
+            color (float): A color (``colour.Color``).
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return ApplyStyle(Style(line_color=color), self)
 
     def fill_color(self, color: Color) -> "Diagram":
+        """Apply specified fill-color to the diagram.
+
+        Args:
+            color (float): A color (``colour.Color``).
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return ApplyStyle(Style(fill_color=color), self)
 
     def fill_opacity(self, opacity: float) -> "Diagram":
+        """Apply specified amount of opacity to the diagram.
+
+        Args:
+            opacity (float): Amount of opacity (between 0 and 1).
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return ApplyStyle(Style(fill_opacity=opacity), self)
 
     def dashing(
         self, dashing_strokes: List[float], offset: float
     ) -> "Diagram":
+        """Apply dashing to a diagram.
+
+        > [TODO]: improve args description.
+
+        Args:
+            dashing_strokes (List[float]): Dashing strokes
+            offset (float): Amount of offset
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return ApplyStyle(Style(dashing=(dashing_strokes, offset)), self)
 
     def at_center(self, other: "Diagram") -> "Diagram":
@@ -298,6 +512,11 @@ class Diagram(tx.Transformable):
         return Compose(new_box, self, ApplyTransform(t, other))
 
     def show_origin(self) -> "Diagram":
+        """Show a ``red`` dot at the origin of a diagram.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         origin_size = min(box.height, box.width) / 50
         origin = Primitive(
@@ -306,6 +525,11 @@ class Diagram(tx.Transformable):
         return self + origin
 
     def show_bounding_box(self) -> "Diagram":
+        """Show ``red`` bounding box of a diagram.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box = self.get_bounding_box()
         origin = Primitive(
             Rectangle(box.width, box.height),
@@ -315,6 +539,14 @@ class Diagram(tx.Transformable):
         return self + origin
 
     def named(self, name: str) -> "Diagram":
+        """Add a name to a diagram.
+
+        Args:
+            name (str): Diagram name.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         return ApplyName(name, self)
 
     def get_subdiagram_bounding_box(

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -23,6 +23,7 @@ Ident = tx.Identity()
 @dataclass
 class Diagram(tx.Transformable):
     """A Diagram class (``chalk.core.Diagram``)."""
+
     def get_bounding_box(self, t: tx.Transform = Ident) -> BoundingBox:
         """Get the bounding box of a diagram."""
         raise NotImplementedError

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -22,7 +22,7 @@ Ident = tx.Identity()
 
 @dataclass
 class Diagram(tx.Transformable):
-    """A Diagram class (``chalk.core.Diagram``)."""
+    """Diagram class (``chalk.core.Diagram``)."""
 
     def get_bounding_box(self, t: tx.Transform = Ident) -> BoundingBox:
         """Get the bounding box of a diagram."""

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -490,7 +490,7 @@ class Diagram(tx.Transformable):
     def dashing(
         self, dashing_strokes: List[float], offset: float
     ) -> "Diagram":
-        """Apply dashing to a diagram.
+        """Apply dashed line to the edge of a diagram.
 
         > [TODO]: improve args description.
 
@@ -504,6 +504,20 @@ class Diagram(tx.Transformable):
         return ApplyStyle(Style(dashing=(dashing_strokes, offset)), self)
 
     def at_center(self, other: "Diagram") -> "Diagram":
+        """Center two given diagrams.
+
+        💡 `a.at_center(b)` means center of ``a`` is translated
+        to the center of ``b``, and ``b`` sits on top of
+        ``a`` along the axis out of the plane of the image.
+
+        💡 In other words, ``b`` occludes ``a``.
+
+        Args:
+            other (Diagram): Another diagram object.
+
+        Returns:
+            Diagram: A diagram object.
+        """
         box1 = self.get_bounding_box()
         box2 = other.get_bounding_box()
         c = box1.center

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -22,7 +22,9 @@ Ident = tx.Identity()
 
 @dataclass
 class Diagram(tx.Transformable):
+    """A Diagram class (``chalk.core.Diagram``)."""
     def get_bounding_box(self, t: tx.Transform = Ident) -> BoundingBox:
+        """Get the bounding box of a diagram."""
         raise NotImplementedError
 
     def to_list(self, t: tx.Transform = Ident) -> List["Primitive"]:
@@ -144,7 +146,7 @@ class Diagram(tx.Transformable):
         return svg
 
     def atop(self, other: "Diagram") -> "Diagram":
-        """Given to diagrams ``a`` and ``b``, ``a.atop(b)``
+        """Given two diagrams ``a`` and ``b``, ``a.atop(b)``
         places ``a`` and ``b`` such that none of them move.
         This is equivalent to **union** operation of two the
         shapes.
@@ -165,7 +167,7 @@ class Diagram(tx.Transformable):
     __add__ = atop
 
     def beside(self, other: "Diagram") -> "Diagram":
-        """Given to diagrams ``a`` and ``b``, ``a.beside(b)``
+        """Given two diagrams ``a`` and ``b``, ``a.beside(b)``
         places ``b`` on the right side of ``a``. This moves
         ``b`` up to touch ``a``.
 
@@ -187,7 +189,7 @@ class Diagram(tx.Transformable):
     __or__ = beside
 
     def above(self, other: "Diagram") -> "Diagram":
-        """Given to diagrams ``a`` and ``b``, ``a.above(b)``
+        """Given two diagrams ``a`` and ``b``, ``a.above(b)``
         places ``b`` under ``a``. This moves ``b`` up to
         touch ``a``.
 
@@ -209,7 +211,7 @@ class Diagram(tx.Transformable):
     __truediv__ = above
 
     def above2(self, other: "Diagram") -> "Diagram":
-        """Given to diagrams ``a`` and ``b``, ``a.above2(b)``
+        """Given two diagrams ``a`` and ``b``, ``a.above2(b)``
         places ``a`` on top of ``b``. This moves ``a`` down to
         touch ``b``.
 
@@ -566,9 +568,11 @@ class Diagram(tx.Transformable):
     def get_subdiagram_bounding_box(
         self, name: str, t: tx.Transform = Ident
     ) -> Optional[BoundingBox]:
+        """Get the bounding box of the sub-diagram."""
         return None
 
     def to_svg(self, dwg: Drawing, style: Style) -> BaseElement:
+        """Convert a diagram to SVG image."""
         raise NotImplementedError
 
 

--- a/chalk/point.py
+++ b/chalk/point.py
@@ -7,58 +7,165 @@ from chalk import transform as tx
 
 @dataclass
 class Point(tx.Transformable):
+    """Point class.
+
+    This is a point in 2D and so has ``(x,y)``
+    coordinates, and no ``z``-coordinate.
+    """
+
     x: float
     y: float
 
     def apply_transform(self, t: tx.Transform):  # type: ignore
+        """Applies a transformation to the point and
+        returns the transformed point.
+
+        Args:
+            t (Transform): A transform object (``chalk.transform.Transform``)
+
+        Returns:
+            Point: A point object.
+        """
         new_x, new_y = t().transform_point(self.x, self.y)
         return Point(new_x, new_y)
 
     def __add__(self, other: "Vector") -> "Point":
+        """Adds a vector to a point.
+
+        Args:
+            other (Vector): A vector object (``chalk.point.Vector``).
+
+        Returns:
+            Point: A point object.
+        """
         return Point(self.x + other.dx, self.y + other.dy)
 
     def __sub__(self, other: "Point") -> "Vector":
+        """Subtracts another point from this point and
+        returns a vector.
+
+        Args:
+            other (Point): A point object.
+
+        Returns:
+            Vector: A vector object (``chalk.point.Vector``).
+        """
         return Vector(self.x - other.x, self.y - other.y)
 
 
 @dataclass
 class Vector(tx.Transformable):
+    """Vector class.
+
+    This is a 2D vector.
+    """
+
     dx: float
     dy: float
 
     @property
     def length(self) -> float:
+        """Returns the length of the vector.
+
+        Returns:
+            float: Length of the vector.
+        """
         return math.sqrt(self.dx**2 + self.dy**2)
 
     @property
     def angle(self) -> float:
+        """Returns the angle of the vector.
+
+        Returns:
+            float: Angle of the vector (in radians).
+        """
         return math.atan2(self.dy, self.dx)
 
     @classmethod
     def from_polar(cls, r: float, angle: float) -> "Vector":
+        """Returns (constructs) a vector from polar-coordinate
+        input ``(r, angle)``.
+
+        Args:
+            r (float): Length of the vector.
+            angle (float): Angle of the vector (in radians).
+
+        Returns:
+            Vector: A vector object.
+        """
         dx = r * math.cos(angle)
         dy = r * math.sin(angle)
         return cls(dx, dy)
 
     def apply_transform(self, t: tx.Transform):  # type:ignore
+        """Applies a transformation on a vector
+        and returns the transformed vector.
+
+        Args:
+            t (Transform): The transformation to apply.
+
+        Returns:
+            Vector: A vector object.
+        """
         new_dx, new_dy = t().transform_point(self.dx, self.dy)
         return Vector(new_dx, new_dy)
 
     def rotate(self, by: float) -> "Vector":
+        """Returns a rotated vector.
+
+        Args:
+            by (float): Angle of rotation (in radians)
+
+        Returns:
+            Vector: A vector object.
+        """
         return Vector.from_polar(self.length, self.angle + by)
 
     def __mul__(self, α: float) -> "Vector":
+        """Returns a scaled a vector.
+
+        Args:
+            α (float): Scaling factor.
+
+        Returns:
+            Vector: A vector object.
+        """
         return Vector(α * self.dx, α * self.dy)
 
     __rmul__ = __mul__
 
     def __add__(self, other: "Vector") -> "Vector":
+        """Adds another vector to this vector and
+        returns the resulting vector.
+
+        Args:
+            other (Vector): Another vector.
+
+        Returns:
+            Vector: A vector object.
+        """
         return Vector(self.dx + other.dx, self.dy + other.dy)
 
     def __sub__(self, other: "Vector") -> "Vector":
+        """Subtracts another vector from this vector and
+        returns the resulting vector.
+
+        Args:
+            other (Vector): Another vector.
+
+        Returns:
+            Vector: A vector object.
+        """
         return Vector(self.dx - other.dx, self.dy - other.dy)
 
     def __neg__(self) -> "Vector":
+        """Returns a negated vector.
+
+        This flips the signs of the ``x`` and ``y`` components.
+
+        Returns:
+            Vector: A vector object.
+        """
         return Vector(-self.dx, -self.dy)
 
 

--- a/chalk/point.py
+++ b/chalk/point.py
@@ -28,7 +28,7 @@ class Vector(tx.Transformable):
 
     @property
     def length(self) -> float:
-        return math.sqrt(self.dx ** 2 + self.dy ** 2)
+        return math.sqrt(self.dx**2 + self.dy**2)
 
     @property
     def angle(self) -> float:

--- a/chalk/point.py
+++ b/chalk/point.py
@@ -9,6 +9,8 @@ from chalk import transform as tx
 class Point(tx.Transformable):
     """Point class.
 
+    This is derived from a ``chalk.transform.Transformable`` class.
+
     This is a point in 2D and so has ``(x,y)``
     coordinates, and no ``z``-coordinate.
     """
@@ -56,6 +58,8 @@ class Point(tx.Transformable):
 @dataclass
 class Vector(tx.Transformable):
     """Vector class.
+
+    This is derived from a ``chalk.transform.Transformable`` class.
 
     This is a 2D vector.
     """

--- a/chalk/point.py
+++ b/chalk/point.py
@@ -9,8 +9,6 @@ from chalk import transform as tx
 class Point(tx.Transformable):
     """Point class.
 
-    This is derived from a ``chalk.transform.Transformable`` class.
-
     This is a point in 2D and so has ``(x,y)``
     coordinates, and no ``z``-coordinate.
     """
@@ -23,7 +21,7 @@ class Point(tx.Transformable):
         returns the transformed point.
 
         Args:
-            t (Transform): A transform object (``chalk.transform.Transform``)
+            t (Transform): A transform object.
 
         Returns:
             Point: A point object.
@@ -35,7 +33,7 @@ class Point(tx.Transformable):
         """Adds a vector to a point.
 
         Args:
-            other (Vector): A vector object (``chalk.point.Vector``).
+            other (Vector): A vector object.
 
         Returns:
             Point: A point object.
@@ -50,7 +48,7 @@ class Point(tx.Transformable):
             other (Point): A point object.
 
         Returns:
-            Vector: A vector object (``chalk.point.Vector``).
+            Vector: A vector object.
         """
         return Vector(self.x - other.x, self.y - other.y)
 
@@ -58,8 +56,6 @@ class Point(tx.Transformable):
 @dataclass
 class Vector(tx.Transformable):
     """Vector class.
-
-    This is derived from a ``chalk.transform.Transformable`` class.
 
     This is a 2D vector.
     """

--- a/chalk/shape.py
+++ b/chalk/shape.py
@@ -21,6 +21,8 @@ PyCairoContext = Any
 
 @dataclass
 class Shape:
+    """Shape class."""
+
     def get_bounding_box(self) -> BoundingBox:
         pass
 
@@ -33,6 +35,8 @@ class Shape:
 
 @dataclass
 class Circle(Shape):
+    """Circle class."""
+
     radius: float
 
     def get_bounding_box(self) -> BoundingBox:
@@ -49,6 +53,8 @@ class Circle(Shape):
 
 @dataclass
 class Rectangle(Shape):
+    """Rectangle class."""
+
     width: float
     height: float
     radius: Optional[float] = None
@@ -86,6 +92,8 @@ class Rectangle(Shape):
 
 @dataclass
 class Path(Shape, tx.Transformable):
+    """Path class."""
+
     points: List[Point]
     arrow: bool = False
 
@@ -144,6 +152,8 @@ class Path(Shape, tx.Transformable):
 
 @dataclass
 class Arc(Shape):
+    """Arc class."""
+
     radius: float
     angle0: float
     angle1: float
@@ -174,6 +184,8 @@ class Arc(Shape):
 
 @dataclass
 class Text(Shape):
+    """Text class."""
+
     text: str
     font_size: Optional[float]
 
@@ -233,6 +245,8 @@ def from_pil(
 
 @dataclass
 class Image(Shape):
+    """Image class."""
+
     local_path: str
     url_path: Optional[str]
 
@@ -269,6 +283,8 @@ class Image(Shape):
 
 @dataclass
 class Spacer(Shape):
+    """Spacer class."""
+
     width: float
     height: float
 
@@ -281,7 +297,10 @@ class Spacer(Shape):
 
 
 class Raw(Rect):  # type: ignore
-    "A fake SVG node for importing latex"
+    """Shape class.
+
+    A fake SVG node for importing latex.
+    """
 
     def __init__(self, st: str):
         self.xml = ET.fromstring(st)
@@ -292,6 +311,8 @@ class Raw(Rect):  # type: ignore
 
 @dataclass
 class Latex(Shape):
+    """Latex class."""
+
     text: str
 
     def __post_init__(self) -> None:

--- a/chalk/style.py
+++ b/chalk/style.py
@@ -18,6 +18,8 @@ LW = 0.01
 
 @dataclass
 class Style:
+    """Style class."""
+
     line_width: Optional[float] = None
     line_color: Optional[Color] = None
     fill_color: Optional[Color] = None
@@ -29,6 +31,14 @@ class Style:
         return cls()
 
     def merge(self, other: "Style") -> "Style":
+        """Merges two styles and returns the merged style.
+
+        Args:
+            other (Style): Another style object.
+
+        Returns:
+            Style: A style object.
+        """
         return Style(
             *(
                 m(getattr(other, dim.name), getattr(self, dim.name))
@@ -37,6 +47,11 @@ class Style:
         )
 
     def render(self, ctx: PyCairoContext) -> None:
+        """Renders the style object.
+
+        Args:
+            ctx (PyCairoContext): A context.
+        """
         if self.fill_color:
             ctx.set_source_rgb(*self.fill_color.rgb)
             ctx.fill_preserve()
@@ -61,6 +76,11 @@ class Style:
         ctx.stroke()
 
     def to_svg(self) -> str:
+        """Converts to SVG.
+
+        Returns:
+            str: A string notation of the SVG.
+        """
         style = ""
         if self.fill_color is not None:
             style += f"fill: {self.fill_color.hex_l};"

--- a/chalk/trail.py
+++ b/chalk/trail.py
@@ -35,7 +35,7 @@ class Trail(tx.Transformable):
         """Constructs and returns a trail from a given path.
 
         Args:
-            path (Path): A path object (``chalk.shape.Path``).
+            path (Path): A path object.
 
         Returns:
             Trail: A trail object.
@@ -48,11 +48,11 @@ class Trail(tx.Transformable):
         """Converts a trail to a path, given a point (as a reference).
 
         Args:
-            origin (Point, optional): A point object (``chalk.point.Point``).
+            origin (Point, optional): A point object.
                                       Defaults to ORIGIN.
 
         Returns:
-            Path: A path object (``chalk.shape.Path``).
+            Path: A path object.
         """
         points = [origin]
         for s in self.offsets:
@@ -63,8 +63,7 @@ class Trail(tx.Transformable):
         """Returns a primitive (shape) with strokes
 
         Returns:
-            Primitive: A primitive object with strokes
-                       (``chalk.core.Primitive.``).
+            Primitive: A primitive object with strokes.
         """
         return Primitive.from_shape(self.to_path())
 
@@ -73,7 +72,7 @@ class Trail(tx.Transformable):
         returns the resulting trail.
 
         Args:
-            t (Transform): A transform object (``chalk.transform.Transform``)
+            t (Transform): A transform object.
 
         Returns:
             Trail: A trail object.
@@ -86,7 +85,7 @@ class Trail(tx.Transformable):
         This is the same as ``Trail.transform()`` method.
 
         Args:
-            t (Transform): A transform object (``chalk.transform.Transform``)
+            t (Transform): A transform object.
 
         Returns:
             Trail: A trail object.

--- a/chalk/trail.py
+++ b/chalk/trail.py
@@ -7,6 +7,13 @@ from chalk import transform as tx
 
 
 class Trail(tx.Transformable):
+    """Trail class.
+
+    This is derived from a ``chalk.transform.Transformable`` class.
+
+    [TODO]: Need more explanation on what this class is for (preferably
+    with illustrations/figures).
+    """
     def __init__(self, offsets: List[Vector]):
         self.offsets = offsets
 

--- a/chalk/trail.py
+++ b/chalk/trail.py
@@ -14,31 +14,83 @@ class Trail(tx.Transformable):
     [TODO]: Need more explanation on what this class is for (preferably
     with illustrations/figures).
     """
+
     def __init__(self, offsets: List[Vector]):
         self.offsets = offsets
 
     def __add__(self, other: "Trail") -> "Trail":
+        """Adds another trail to this one and
+        returns the resulting trail.
+
+        Args:
+            other (Trail): Another trail object.
+
+        Returns:
+            Trail: A trail object.
+        """
         return Trail(self.offsets + other.offsets)
 
     @classmethod
     def from_path(cls, path: Path) -> "Trail":
+        """Constructs and returns a trail from a given path.
+
+        Args:
+            path (Path): A path object (``chalk.shape.Path``).
+
+        Returns:
+            Trail: A trail object.
+        """
         pts = path.points
         offsets = [t - s for s, t in zip(pts, pts[1:])]
         return cls(offsets)
 
     def to_path(self, origin: Point = ORIGIN) -> Path:
+        """Converts a trail to a path, given a point (as a reference).
+
+        Args:
+            origin (Point, optional): A point object (``chalk.point.Point``).
+                                      Defaults to ORIGIN.
+
+        Returns:
+            Path: A path object (``chalk.shape.Path``).
+        """
         points = [origin]
         for s in self.offsets:
             points.append(points[-1] + s)
         return Path(points)
 
     def stroke(self) -> Primitive:
+        """Returns a primitive (shape) with strokes
+
+        Returns:
+            Primitive: A primitive object with strokes
+                       (``chalk.core.Primitive.``).
+        """
         return Primitive.from_shape(self.to_path())
 
     def transform(self, t: tx.Transform) -> "Trail":
+        """Applies a transform on the trail and
+        returns the resulting trail.
+
+        Args:
+            t (Transform): A transform object (``chalk.transform.Transform``)
+
+        Returns:
+            Trail: A trail object.
+        """
         return Trail([p.apply_transform(t) for p in self.offsets])
 
     def apply_transform(self, t: tx.Transform) -> "Trail":  # type: ignore
+        """Applies a given transform.
+
+        This is the same as ``Trail.transform()`` method.
+
+        Args:
+            t (Transform): A transform object (``chalk.transform.Transform``)
+
+        Returns:
+            Trail: A trail object.
+        """
         return self.transform(t)
 
 

--- a/chalk/transform.py
+++ b/chalk/transform.py
@@ -7,6 +7,8 @@ import math
 
 @dataclass
 class Transform:
+    """Transform class."""
+
     def __call__(self) -> cairo.Matrix:
         raise NotImplementedError
 
@@ -16,6 +18,8 @@ class Transform:
 
 @dataclass
 class Identity(Transform):
+    """Identity class."""
+
     def __call__(self) -> cairo.Matrix:
         return cairo.Matrix()
 
@@ -25,6 +29,8 @@ class Identity(Transform):
 
 @dataclass
 class Scale(Transform):
+    """Scale class."""
+
     αx: float
     αy: float
 
@@ -39,6 +45,8 @@ class Scale(Transform):
 
 @dataclass
 class Rotate(Transform):
+    """Rotate class."""
+
     θ: float
 
     def __call__(self) -> cairo.Matrix:
@@ -51,6 +59,8 @@ class Rotate(Transform):
 
 @dataclass
 class Translate(Transform):
+    """Translate class."""
+
     dx: float
     dy: float
 
@@ -65,6 +75,8 @@ class Translate(Transform):
 
 @dataclass
 class ShearX(Transform):
+    """ShearX class."""
+
     λ: float
 
     def __call__(self) -> cairo.Matrix:
@@ -77,6 +89,8 @@ class ShearX(Transform):
 
 @dataclass
 class ShearY(Transform):
+    """ShearY class."""
+
     λ: float
 
     def __call__(self) -> cairo.Matrix:
@@ -89,6 +103,8 @@ class ShearY(Transform):
 
 @dataclass
 class Compose(Transform):
+    """Compose class."""
+
     t: Transform
     u: Transform
 
@@ -104,6 +120,8 @@ TTrans = TypeVar("TTrans", bound="Transformable")
 
 
 class Transformable:
+    """Transformable class."""
+
     def apply_transform(self, t: Transform) -> TTrans:
         pass
 

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -11,20 +11,22 @@ _HERE = os.path.dirname(__file__)
 
 try:
     from loguru import logger
+
     logger.remove()
-    logger.add(sys.stdout,
+    logger.add(
+        sys.stdout,
         colorize=True,
-        format="<light-red>{time:HH:mm:ss}</light-red> <level>{message}</level>",
+        format="<light-red>{time:HH:mm:ss}</light-red> <level>{message}</level>",  # noqa: E501
         level="INFO",
-    )
+    )  # noqa: E124
     prnt_success = logger.success
     prnt_warning = logger.warning
 except ImportError:
-    prnt_success = print
-    prnt_warning = print
+    prnt_success = print  # type: ignore
+    prnt_warning = print  # type: ignore
 
 # Define type alias
-# source: https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases # noqa: E501
+# source: https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases  # noqa: E501
 Diagram = TypeVar("Diagram", chalk.core.Diagram, Any)
 
 
@@ -106,7 +108,9 @@ def imgen(
             dir=dirpath, prefix=prefix, suffix=suffix
         ) as fp:
             if verbose:
-                prnt_success(f" ✅ 1. Created temporary file: {os.path.relpath(fp.name)}")
+                prnt_success(
+                    f" ✅ 1. Created temporary file: {os.path.relpath(fp.name)}"
+                )  # noqa: E501
             d.render(fp.name, height=height)
             if verbose:
                 prnt_success(" ✅ 2. Saved rendered image to temporary file.")
@@ -141,14 +145,14 @@ def create_sample_diagram() -> Diagram:
     blue = Color("#005FDB")
     d = circle(0.5).fill_color(papaya).beside(square(1).fill_color(blue))
 
-    return d  # type: ignore
+    return d
 
 
 def quick_probe(
     d: Optional[Diagram] = None,
     dirpath: Optional[str] = None,
     verbose: bool = True,
-    **kwargs
+    **kwargs: Any,
 ) -> Union[NoReturn, None]:
     """Render diagram and generate an image tempfile (``.png``)
 

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -4,6 +4,7 @@ import tempfile
 import time
 from typing import Optional, Any, TypeVar
 from PIL import Image as PILImage
+from colour import Color
 
 import chalk
 
@@ -139,7 +140,6 @@ def create_sample_diagram() -> Diagram:
     Returns:
         Diagram: Returns a sample diagram.
     """
-    from colour import Color
     from chalk import circle, square
 
     papaya = Color("#ff9700")

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -164,7 +164,7 @@ def create_sample_diagram(
     b = square(1).fill_color(blue)
 
     if option is None:
-        d = a.beside(b)
+        d = a.beside(b) # a|b
     else:
         option = "".join(option.split())
         # handle specific cases

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -1,0 +1,138 @@
+import os
+import sys
+import tempfile
+import time
+from typing import NoReturn, Union, Optional, Any, TypeVar
+
+from PIL import Image as PILImage
+
+import chalk
+
+HERE = os.path.dirname(__file__)
+
+# Define type alias
+# source: https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases # noqa: E501
+Diagram = TypeVar("Diagram", chalk.core.Diagram, Any)
+
+
+def show(filepath: str):  # type: ignore
+    """Show image from filepath.
+
+    Args:
+        filepath (str): Filepath of the image.
+                        example: "examples/output/intro-01-a.png"
+    """
+    PILImage.open(filepath).show()
+
+
+def imgen(
+    d: Diagram,
+    temporary: bool = True,
+    dirpath: Optional[str] = "examples/output",
+    prefix: str = "trial_",
+    suffix: str = "_image.png",
+    height: int = 64,
+    wait: int = 5,
+) -> Union[NoReturn, None]:
+    """Render a ``chalk`` diagram and visualize.
+
+    Args:
+        d (Diagram): A chalk diagram object (``chalk.Diagram``).
+        temporary (bool, optional): Whether to use a temporary file or not.
+                Defaults to True.
+        dirpath (Optional[str], optional): Directory to save the temporary
+                file in. Defaults to "examples/output".
+        prefix (str, optional): Prefix for the generated image file.
+                Defaults to "trial_".
+        suffix (str, optional): Suffix for the generated image file.
+                Defaults to "_image.png".
+        height (int, optional): Height of the diagram, rendered as an image.
+                Defaults to 64.
+        wait (int, optional): The time (in seconds) to wait until destroying
+                the temporary image file. Defaults to 5.
+
+    Raises:
+        NotImplementedError: For non temporary file (``temporary=False``),
+                             raises an error, as it has not been
+                             implemented yet.
+
+    Returns:
+        Union[NoReturn, None]: Does not return anything.
+    """
+    make_tempdir = False
+    dp = None
+    if temporary:
+        if (dirpath is not None) and (not os.path.isdir(dirpath)):
+            make_tempdir = True
+            dp = tempfile.TemporaryDirectory(
+                dir=".", prefix=prefix, suffix=suffix
+            )
+            dirpath = dp.name
+        with tempfile.NamedTemporaryFile(
+            dir=dirpath, prefix=prefix, suffix=suffix
+        ) as fp:
+            print(f"1. Created temporary file: {os.path.relpath(fp.name)}")
+            d.render(fp.name, height=height)
+            print("2. Saved rendered image to temporary file.")
+            fp.seek(0)
+            print("3. Displaying image from temporary file.")
+            show(fp.name)
+            time.sleep(wait)
+
+        print("4. Closed and removed temporary image!")
+
+        if make_tempdir and dp:
+            # Cleanup temporary directory
+            dp.cleanup()
+    else:
+        raise NotImplementedError(
+            "Only temporary file creation + load + display is supported."
+        )
+
+
+def quick_probe(
+    d: Optional[Diagram] = None,
+    dirpath: Optional[str] = None,
+    verbose: bool = True,
+) -> Union[NoReturn, None]:
+    """Render diagram and generate an image tempfile (``.png``)
+
+    This utility is made to quickly create a diagram and display it,
+    without saving any permanent image file on disk.
+
+    Args:
+        d (Optional[Diagram], optional): A chalk diagram object
+                (``chalk.Diagram``). Defaults to None.
+        dirpath (Optional[str], optional): Directory to save the temporary
+                file in. For example, you could use "examples/output" with
+                respect to the location of running a script.
+                Defaults to None.
+        verbose (bool): Set verbosity. Defaults to True.
+
+    Usage:
+        quick_probe(verbose=True)
+    """
+    if verbose:
+        print(f"{chalk.__name__} version: v{chalk.__version__}")
+    if d is None:
+        from colour import Color
+        from chalk import circle, square
+
+        papaya = Color("#ff9700")
+        blue = Color("#005FDB")
+        d = circle(0.5).fill_color(papaya).beside(square(1).fill_color(blue))
+    if dirpath is None:
+        dirpath = os.path.join(HERE, "../examples/output")
+    # render diagram and generate an image tempfile (.png)
+    imgen(d, dirpath=dirpath)
+
+
+if __name__ == "__main__":
+
+    # determine initial directory
+    root = os.path.abspath(os.curdir)
+    # update sys-path
+    sys.path.append(HERE)
+    os.chdir(HERE)  # change directory
+    quick_probe(verbose=True)  # generate diagram
+    os.chdir(root)  # switch back to initial directory

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -9,6 +9,20 @@ import chalk
 
 _HERE = os.path.dirname(__file__)
 
+try:
+    from loguru import logger
+    logger.remove()
+    logger.add(sys.stdout,
+        colorize=True,
+        format="<light-red>{time:HH:mm:ss}</light-red> <level>{message}</level>",
+        level="INFO",
+    )
+    prnt_success = logger.success
+    prnt_warning = logger.warning
+except ImportError:
+    prnt_success = print
+    prnt_warning = print
+
 # Define type alias
 # source: https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases # noqa: E501
 Diagram = TypeVar("Diagram", chalk.core.Diagram, Any)
@@ -89,15 +103,15 @@ def imgen(
         with tempfile.NamedTemporaryFile(
             dir=dirpath, prefix=prefix, suffix=suffix
         ) as fp:
-            print(f"1. Created temporary file: {os.path.relpath(fp.name)}")
+            prnt_success(f" ✅ 1. Created temporary file: {os.path.relpath(fp.name)}")
             d.render(fp.name, height=height)
-            print("2. Saved rendered image to temporary file.")
+            prnt_success(" ✅ 2. Saved rendered image to temporary file.")
             fp.seek(0)
-            print("3. Displaying image from temporary file.")
+            prnt_success(" ✅ 3. Displaying image from temporary file.")
             show(fp.name)
             time.sleep(wait)
 
-        print("4. Closed and removed temporary image!")
+        prnt_success(" ✅ 4. Closed and removed temporary image!")
 
         if make_tempdir and dp:
             # Cleanup temporary directory
@@ -147,7 +161,7 @@ def quick_probe(
         quick_probe(verbose=True)
     """
     if verbose:
-        print(f"{chalk.__name__} version: v{chalk.__version__}")
+        prnt_warning(f"{chalk.__name__} version: v{chalk.__version__}")
     if d is None:
         d = create_sample_diagram()
     if dirpath is None:

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -123,7 +123,7 @@ def imgen(
             time.sleep(wait)
 
         if verbose:
-            prnt_success(" ✅ 4. Closed and removed temporary image!")
+            prnt_success(" ✅ 4. Removed temporary image file!")
 
         if make_tempdir and dp:
             # Cleanup temporary directory

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -2,7 +2,7 @@ import os
 import sys
 import tempfile
 import time
-from typing import Optional, Any, TypeVar
+from typing import Optional, Any, Tuple, TypeVar, Union
 from PIL import Image as PILImage
 from colour import Color
 
@@ -134,9 +134,25 @@ def imgen(
         )
 
 
-def create_sample_diagram() -> Diagram:
+def create_sample_diagram(
+    option: Optional[str] = "a|b",
+) -> Union[Diagram, Tuple[Diagram, Diagram]]:
     """Creates a sample diagram.
 
+    Args:
+        option (Optional[str], optional): A string denoting what
+            kind of sample diagram(s) to return.
+            💡 Choose from:
+            - "a+b" : means a.atop(b)    | Single Diagram
+            - "b+a" : means b.atop(a)    | Single Diagram
+            - "a|b" : means a.beside(b)  | Single Diagram
+            - "b|a" : means b.beside(a)  | Single Diagram
+            - "a/b" : means a.above(b)   | Single Diagram
+            - "b/a" : means b.above(a)   | Single Diagram
+            - "a//b": means a.above2(b)  | Single Diagram
+            - "b//a": means b.above2(a)  | Single Diagram
+            - "a,b" : means (a, b) --> ✨| Two Diagrams
+            💡 Defaults to "a|b".
     Returns:
         Diagram: Returns a sample diagram.
     """
@@ -144,9 +160,46 @@ def create_sample_diagram() -> Diagram:
 
     papaya = Color("#ff9700")
     blue = Color("#005FDB")
-    d = circle(0.5).fill_color(papaya).beside(square(1).fill_color(blue))
+    a = circle(0.5).fill_color(papaya)
+    b = square(1).fill_color(blue)
 
+    if option is None:
+        d = a.beside(b)
+    else:
+        option = "".join(option.split())
+        # handle specific cases
+        if option == "a+b":
+            d = a + b  # a.atop(b)
+        if option == "b+a":
+            d = b + a  # b.atop(a)
+        elif option == "a|b":
+            d = a | b  # a.beside(b)
+        elif option == "a|b":
+            d = b | a  # b.beside(a)
+        elif option == "a/b":
+            d = a / b  # a.above(b)
+        elif option == "b/a":
+            d = b / a  # b.above(a)
+        elif option == "a//b":
+            d = a // b  # a.above2(b)
+        elif option == "b//a":
+            d = b // a  # b.above2(a)
+        elif option == "a,b":
+            d = (a, b)  # type: ignore
+        elif option == "b,a":
+            d = (b, a)  # type: ignore
     return d  # type: ignore
+
+
+def create_double_diagrams() -> Tuple[Diagram, Diagram]:
+    """Creates a pair of sample diagrams (a circle and a square).
+
+    Returns:
+        Diagram: Returns a sample diagram.
+    """
+    a, b = create_sample_diagram(option="a,b")  # type: ignore
+
+    return (a, b)
 
 
 def quick_probe(
@@ -177,7 +230,7 @@ def quick_probe(
     # if verbose:
     #     prnt_warning(f"{chalk.__name__} version: v{chalk.__version__}")
     if d is None:
-        d = create_sample_diagram()
+        d = create_sample_diagram()  # type: ignore
     if dirpath is None:
         dirpath = os.path.join(_HERE, "../examples/output")
     # render diagram and generate an image tempfile (.png)

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -1,3 +1,22 @@
+"""
+The ``chalk.utils`` module is meant to provide various
+utility-oriented functionalities.
+
+Importing:
+
+    ```python
+    # method-1
+    from chalk import utils as U
+
+    # method-2
+    import chalk.utils
+
+    # method-3
+    from chalk.utils import <some_function>
+
+    ```
+"""
+
 import os
 import sys
 import tempfile
@@ -29,12 +48,19 @@ except ImportError:
 Diagram = TypeVar("Diagram")
 
 
-def show(filepath: str):  # type: ignore
+def show(filepath: str) -> None:
     """Show image from filepath.
 
     Args:
         filepath (str): Filepath of the image.
                         example: "examples/output/intro-01-a.png"
+
+    Usage:
+
+        ```python
+        from chalk.utils import show
+        show("examples/output/intro-01.png")
+        ```
     """
     PILImage.open(filepath).show()
 
@@ -77,8 +103,11 @@ def imgen(
         Union[NoReturn, None]: Does not return anything.
 
     Usage:
+
+        ```python
         from colour import Color
         from chalk import circle
+        from chalk.utils import imgen
 
         papaya = Color("#ff9700")
         d = circle(0.5).fill_color(papaya)
@@ -94,6 +123,7 @@ def imgen(
 
         # Display and delete the temporary file after 10 seconds
         imgen(d, temporary=True, wait=10)
+        ```
     """
     make_tempdir = False
     dp = None
@@ -142,19 +172,50 @@ def create_sample_diagram(
     Args:
         option (Optional[str], optional): A string denoting what
             kind of sample diagram(s) to return.
-            💡 Choose from:
-            - "a+b" : means a.atop(b)    | Single Diagram
-            - "b+a" : means b.atop(a)    | Single Diagram
-            - "a|b" : means a.beside(b)  | Single Diagram
-            - "b|a" : means b.beside(a)  | Single Diagram
-            - "a/b" : means a.above(b)   | Single Diagram
-            - "b/a" : means b.above(a)   | Single Diagram
-            - "a//b": means a.above2(b)  | Single Diagram
-            - "b//a": means b.above2(a)  | Single Diagram
-            - "a,b" : means (a, b) --> ✨| Two Diagrams
-            💡 Defaults to "a|b".
+            💡 Defaults to ``"a|b"``.
+
+    Choose ``option`` from for the following.
+
+    Click to expand:
+
+        |   Option    |      Meaning      |     Output      |
+        |:-----------:|:------------------|:---------------:|
+        | ``"a+b"``   | ``a.atop(b)``     | Single Diagram  |
+        | ``"b+a"``   | ``b.atop(a)``     | Single Diagram  |
+        | ``"a|b"``   | ``a.beside(b)``   | Single Diagram  |
+        | ``"b|a"``   | ``b.beside(a)``   | Single Diagram  |
+        | ``"a/b"``   | ``a.above(b)``    | Single Diagram  |
+        | ``"b/a"``   | ``b.above(a)``    | Single Diagram  |
+        | ``"a//b"``  | ``a.above2(b)``   | Single Diagram  |
+        | ``"b//a"``  | ``b.above2(a)``   | Single Diagram  |
+        | ``"a,b"``   | ``(a, b)``        | Two Diagrams    |
+
     Returns:
         Diagram: Returns a sample diagram.
+
+    Usage:
+
+        ```python
+        from chalk.utils import create_sample_diagram
+
+        # create a diagram composed of two diagrams: a|b
+        d = create_sample_diagram(option="a|b")
+
+        # create a diagram composed of two diagrams: b|a
+        d = create_sample_diagram(option="b|a")
+
+        # create a diagram composed of two diagrams: a+b
+        d = create_sample_diagram(option="a+b")
+
+        # create a diagram composed of two diagrams: a/b
+        d = create_sample_diagram(option="a/b")
+
+        # create a diagram composed of two diagrams: a//b
+        d = create_sample_diagram(option="a//b")
+
+        # create two diagrams: (a,b)
+        a, b = create_sample_diagram(option="a,b")
+        ```
     """
     from chalk import circle, square
 
@@ -225,7 +286,11 @@ def quick_probe(
         verbose (bool): Set verbosity. Defaults to True.
 
     Usage:
-        quick_probe(verbose=True)
+
+        ```python
+        from chalk.utils import quick_probe
+        quick_probe(verbose=True, wait=2)
+        ```
     """
     # if verbose:
     #     prnt_warning(f"{chalk.__name__} version: v{chalk.__version__}")

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -2,7 +2,7 @@ import os
 import sys
 import tempfile
 import time
-from typing import NoReturn, Union, Optional, Any, TypeVar
+from typing import Optional, Any, TypeVar
 from PIL import Image as PILImage
 
 import chalk
@@ -25,6 +25,8 @@ except ImportError:
     prnt_success = print  # type: ignore
     prnt_warning = print  # type: ignore
 
+Diagram = TypeVar("Diagram")
+
 
 def show(filepath: str):  # type: ignore
     """Show image from filepath.
@@ -37,7 +39,7 @@ def show(filepath: str):  # type: ignore
 
 
 def imgen(
-    d: "Diagram",
+    d: Diagram,
     temporary: bool = True,
     dirpath: Optional[str] = "examples/output",
     prefix: str = "trial_",
@@ -45,7 +47,7 @@ def imgen(
     height: int = 64,
     wait: int = 5,
     verbose: bool = True,
-) -> Union[NoReturn, None]:
+) -> None:
     """Render a ``chalk`` diagram and visualize.
 
     Args:
@@ -53,7 +55,8 @@ def imgen(
         temporary (bool, optional): Whether to use a temporary file or not.
                 Defaults to True.
         dirpath (Optional[str], optional): Directory to save the temporary
-                file in. Defaults to "examples/output".
+                file in. If does not exist, creates a temporary directory
+                and destroys it afterwards. Defaults to "examples/output".
         prefix (str, optional): Prefix for the generated image file.
                 Defaults to "trial_".
         suffix (str, optional): Suffix for the generated image file.
@@ -93,6 +96,8 @@ def imgen(
     """
     make_tempdir = False
     dp = None
+    if verbose:
+        prnt_warning(f" ✨ {chalk.__name__} version: v{chalk.__version__}")
     if temporary:
         if (dirpath is not None) and (not os.path.isdir(dirpath)):
             make_tempdir = True
@@ -105,9 +110,9 @@ def imgen(
         ) as fp:
             if verbose:
                 prnt_success(
-                    f" ✅ 1. Created temporary file: {os.path.relpath(fp.name)}"
+                    f" ✅ 1. Created temporary file: \n\t\t{os.path.relpath(fp.name)}"  # noqa: E501
                 )  # noqa: E501
-            d.render(fp.name, height=height)
+            d.render(fp.name, height=height)  # type: ignore
             if verbose:
                 prnt_success(" ✅ 2. Saved rendered image to temporary file.")
             fp.seek(0)
@@ -128,7 +133,7 @@ def imgen(
         )
 
 
-def create_sample_diagram() -> "Diagram":
+def create_sample_diagram() -> Diagram:
     """Creates a sample diagram.
 
     Returns:
@@ -141,15 +146,15 @@ def create_sample_diagram() -> "Diagram":
     blue = Color("#005FDB")
     d = circle(0.5).fill_color(papaya).beside(square(1).fill_color(blue))
 
-    return d
+    return d  # type: ignore
 
 
 def quick_probe(
-    d: Optional["Diagram"] = None,
+    d: Optional[Diagram] = None,
     dirpath: Optional[str] = None,
     verbose: bool = True,
     **kwargs: Any,
-) -> Union[NoReturn, None]:
+) -> None:
     """Render diagram and generate an image tempfile (``.png``)
 
     This utility is made to quickly create a sample diagram and display it,
@@ -169,8 +174,8 @@ def quick_probe(
     Usage:
         quick_probe(verbose=True)
     """
-    if verbose:
-        prnt_warning(f"{chalk.__name__} version: v{chalk.__version__}")
+    # if verbose:
+    #     prnt_warning(f"{chalk.__name__} version: v{chalk.__version__}")
     if d is None:
         d = create_sample_diagram()
     if dirpath is None:

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -7,7 +7,7 @@ from PIL import Image as PILImage
 
 import chalk
 
-HERE = os.path.dirname(__file__)
+_HERE = os.path.dirname(__file__)
 
 # Define type alias
 # source: https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases # noqa: E501
@@ -108,6 +108,22 @@ def imgen(
         )
 
 
+def create_sample_diagram() -> Diagram:
+    """Creates a sample diagram.
+
+    Returns:
+        Diagram: Returns a sample diagram.
+    """
+    from colour import Color
+    from chalk import circle, square
+
+    papaya = Color("#ff9700")
+    blue = Color("#005FDB")
+    d = circle(0.5).fill_color(papaya).beside(square(1).fill_color(blue))
+
+    return d  # type: ignore
+
+
 def quick_probe(
     d: Optional[Diagram] = None,
     dirpath: Optional[str] = None,
@@ -133,14 +149,9 @@ def quick_probe(
     if verbose:
         print(f"{chalk.__name__} version: v{chalk.__version__}")
     if d is None:
-        from colour import Color
-        from chalk import circle, square
-
-        papaya = Color("#ff9700")
-        blue = Color("#005FDB")
-        d = circle(0.5).fill_color(papaya).beside(square(1).fill_color(blue))
+        d = create_sample_diagram()
     if dirpath is None:
-        dirpath = os.path.join(HERE, "../examples/output")
+        dirpath = os.path.join(_HERE, "../examples/output")
     # render diagram and generate an image tempfile (.png)
     imgen(d, dirpath=dirpath)
 
@@ -150,7 +161,7 @@ if __name__ == "__main__":
     # determine initial directory
     root = os.path.abspath(os.curdir)
     # update sys-path
-    sys.path.append(HERE)
-    os.chdir(HERE)  # change directory
+    sys.path.append(_HERE)
+    os.chdir(_HERE)  # change directory
     quick_probe(verbose=True)  # generate diagram
     os.chdir(root)  # switch back to initial directory

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -3,7 +3,6 @@ import sys
 import tempfile
 import time
 from typing import NoReturn, Union, Optional, Any, TypeVar
-
 from PIL import Image as PILImage
 
 import chalk
@@ -58,6 +57,25 @@ def imgen(
 
     Returns:
         Union[NoReturn, None]: Does not return anything.
+
+    Usage:
+        from colour import Color
+        from chalk import circle
+
+        papaya = Color("#ff9700")
+        d = circle(0.5).fill_color(papaya)
+
+        # Minimal example
+        imgen(d, temporary=True)
+
+        # Temporary file is created in current directory
+        imgen(d, temporary=True, dirpath=None)
+
+        # Folder path must exist; otherwise temporary folder is used
+        imgen(d, temporary=True, dirpath="examples/output")
+
+        # Display and delete the temporary file after 10 seconds
+        imgen(d, temporary=True, wait=10)
     """
     make_tempdir = False
     dp = None

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -46,6 +46,7 @@ def imgen(
     suffix: str = "_image.png",
     height: int = 64,
     wait: int = 5,
+    verbose: bool = True,
 ) -> Union[NoReturn, None]:
     """Render a ``chalk`` diagram and visualize.
 
@@ -63,6 +64,7 @@ def imgen(
                 Defaults to 64.
         wait (int, optional): The time (in seconds) to wait until destroying
                 the temporary image file. Defaults to 5.
+        verbose (bool): Set verbosity. Defaults to True.
 
     Raises:
         NotImplementedError: For non temporary file (``temporary=False``),
@@ -103,15 +105,19 @@ def imgen(
         with tempfile.NamedTemporaryFile(
             dir=dirpath, prefix=prefix, suffix=suffix
         ) as fp:
-            prnt_success(f" ✅ 1. Created temporary file: {os.path.relpath(fp.name)}")
+            if verbose:
+                prnt_success(f" ✅ 1. Created temporary file: {os.path.relpath(fp.name)}")
             d.render(fp.name, height=height)
-            prnt_success(" ✅ 2. Saved rendered image to temporary file.")
+            if verbose:
+                prnt_success(" ✅ 2. Saved rendered image to temporary file.")
             fp.seek(0)
-            prnt_success(" ✅ 3. Displaying image from temporary file.")
+            if verbose:
+                prnt_success(" ✅ 3. Displaying image from temporary file.")
             show(fp.name)
             time.sleep(wait)
 
-        prnt_success(" ✅ 4. Closed and removed temporary image!")
+        if verbose:
+            prnt_success(" ✅ 4. Closed and removed temporary image!")
 
         if make_tempdir and dp:
             # Cleanup temporary directory
@@ -142,11 +148,14 @@ def quick_probe(
     d: Optional[Diagram] = None,
     dirpath: Optional[str] = None,
     verbose: bool = True,
+    **kwargs
 ) -> Union[NoReturn, None]:
     """Render diagram and generate an image tempfile (``.png``)
 
-    This utility is made to quickly create a diagram and display it,
-    without saving any permanent image file on disk.
+    This utility is made to quickly create a sample diagram and display it,
+    without saving any permanent image file on disk. If a diagram is not
+    provided, a sample diagram is generated. If a diagram is provided, it
+    is displayed.
 
     Args:
         d (Optional[Diagram], optional): A chalk diagram object
@@ -167,7 +176,7 @@ def quick_probe(
     if dirpath is None:
         dirpath = os.path.join(_HERE, "../examples/output")
     # render diagram and generate an image tempfile (.png)
-    imgen(d, dirpath=dirpath)
+    imgen(d, dirpath=dirpath, verbose=verbose, **kwargs)
 
 
 if __name__ == "__main__":

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -25,10 +25,6 @@ except ImportError:
     prnt_success = print  # type: ignore
     prnt_warning = print  # type: ignore
 
-# Define type alias
-# source: https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases  # noqa: E501
-Diagram = TypeVar("Diagram", chalk.core.Diagram, Any)
-
 
 def show(filepath: str):  # type: ignore
     """Show image from filepath.
@@ -41,7 +37,7 @@ def show(filepath: str):  # type: ignore
 
 
 def imgen(
-    d: Diagram,
+    d: "Diagram",
     temporary: bool = True,
     dirpath: Optional[str] = "examples/output",
     prefix: str = "trial_",
@@ -132,7 +128,7 @@ def imgen(
         )
 
 
-def create_sample_diagram() -> Diagram:
+def create_sample_diagram() -> "Diagram":
     """Creates a sample diagram.
 
     Returns:
@@ -149,7 +145,7 @@ def create_sample_diagram() -> Diagram:
 
 
 def quick_probe(
-    d: Optional[Diagram] = None,
+    d: Optional["Diagram"] = None,
     dirpath: Optional[str] = None,
     verbose: bool = True,
     **kwargs: Any,

--- a/chalk/utils.py
+++ b/chalk/utils.py
@@ -164,7 +164,7 @@ def create_sample_diagram(
     b = square(1).fill_color(blue)
 
     if option is None:
-        d = a.beside(b) # a|b
+        d = a.beside(b)  # a|b
     else:
         option = "".join(option.split())
         # handle specific cases

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
-flake8
-black
-mypy
-interrogate

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ svgwrite
 cairosvg
 Pillow
 latextools
+loguru

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,7 @@
+flake8>=3.6.0
+black>=19.3b0
+mypy
+interrogate>=1.5.0
+pre-commit>=2.2.0
+# flake8-print>=4.4.0
+pytest>=4.0.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,0 +1,77 @@
+mkdocs
+mkdocs-material==8.1.3
+mkdocs-material-extensions>=1.0.3
+pymdown-extensions>=9.0
+mdx-include>=1.4.1
+markdown-include>=0.6.0
+mdx_truly_sane_lists>=1.2
+pygments
+
+
+## Navigation & page building
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#navigation--page-building
+mkdocs-exclude>=1.0.2
+mkdocs-awesome-pages-plugin>=2.5.0
+mkdocs-markdownextradata-plugin>=0.2.4
+
+
+## Links & references
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#links--references
+mkdocs-redirects>=1.0.3
+mkdocs-tooltipster-links-plugin>=0.1.0
+
+
+## HTML processing & CSS styling
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#html-processing--css-styling
+mkdocs-minify-plugin>=0.4.1
+mkdocs-enumerate-headings-plugin>=0.4.5
+
+
+## API documentation building
+mkapi
+mkautodoc
+mkdocstrings>=0.16.2
+mkdocs-gen-files>=0.3.3
+mkdocs-autorefs>=0.3.1
+
+
+## Citations & bibliography
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#citations--bibliography
+mkdocs-bibtex>=1.0.0
+
+
+## Code execution, variables & templating
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#code-execution-variables--templating
+mkdocs-jupyter>=0.18.2
+mkdocs-markdownextradata-plugin>=0.2.4
+mkdocs-markmap>=2.1.2
+
+
+## Git repos and info
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#git-repos--info
+mkdocs-macros-plugin>=0.6.0
+mkdocs-git-revision-date-plugin>=0.3.1
+
+
+## Images, Tables, Charts & Graphs
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#images-tables-charts--graphs
+mkdocs-kroki-plugin>=0.2.0
+mkdocs-drawio-exporter>=0.8.0
+mkdocs-table-reader-plugin>=0.6
+
+
+## PDF & site conversion
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#pdf--site-conversion
+# https://doc.courtbouillon.org/weasyprint/latest/first_steps.html#linux
+mkdocs-pdf-export-plugin>=0.5.9
+
+
+## Other
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#other
+mkdocs-tooltips>=0.1.0
+mkdocs-coverage>=0.2.4
+
+
+## Reusing content, snippets & includes
+#  source: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins#reusing-content-snippets--includes
+mkdocs-include-markdown-plugin>=3.2.3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README: str = pathlib.Path("README.md").read_text(encoding="utf-8")
 
 # ---------------------------------------------------------------
 # NOTE:
-# Since the library name (chal-diagrams) is different from
+# Since the library name (chalk-diagrams) is different from
 #   the module (chalk), we set the custom dunder attribute
 #   __libname__ in chalk/__init__.py and use it there to fetch
 #   and set __version__ with library metadata inside

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "svgwrite",
         "cairosvg",
         "Pillow",
+        "loguru",
     ],
     extras_require={"latex": ["latextools"]},
     long_description=README,


### PR DESCRIPTION
This PR adds the functionality of displaying a `chalk.Diagram` with a few convenience functions.

- [x] Adds the new `chalk.utils` module: Closes #44 

  - [x] `utils.show(filepath: str)`: 
    > Use this function for displaying saved images from disk.
  
  - [x] `utils.imgen(d: Diagram, **kwargs)`: 
    > Use this function to display a diagram, without creating any permanent file on disk. 
    > :point_right: This function does the following:
    > 1. Creates a temporary file.
    > 2. If necessary, it also creates a temporary folder for storing the temporary file.
    > 3. Displays the temporary-image-file for a user-specified (optional) `5` seconds.
    > 4. Clears up both the temporary file and folder after the 5 seconds have elapsed.

  - [x] `utils.quick_probe(**kwargs)`:
    > Use this function to **quickly generate a default sample Diagram** (or a user-provided Diagram) and **display it _without saving it_**.

  - [x] `create_sample_diagram()`:
    > Use this function to create a sample diagram, with multiple shapes, colors, etc. -- *with only a single function call*.

I believe, with these utilities it will be quite easy to visualize diagrams without having to save them on the disk.

- [x] Adds a `Diagram.display()` method: Closes #47
  > This facilitats convenient visualization of a diagram without saving any image file permanently on disk. 

- [x] Adds docstrings to methods of:
  - [x] `chalk.core.Diagram` class. Closes #46 
  - [x] `chalk.bounding_box.BoundingBox` class. Closes #48  
  - [x] `chalk.point.Point` class. Closes #50 
  - [x] `chalk.point.Vector` class. Closes #49 
  - [x] `chalk.trail.Trail` class. Closes #51 
  - [x] all the classes other than `Diagram` in `chalk/core.py`: Closes #52