### PR TITLE
Updates workflow: `checks.yml`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Format with [[ isort ]]
       run: |
         # stop the build if there are errors raised by isort
-        make black
+        make isort
     - name: Format with [[ black ]]
       run: |
         # stop the build if there are errors raised by black


### PR DESCRIPTION
- [x] adds `isort` command
- [x] was a typo: `black` was being called instead of `isort`

This fixes a bug in GitHub actions: `isort` was not being called at all.

Closes #62 