### PR TITLE
Planar replace

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,6 @@ jobs:
         sudo apt-get install libcairo2-dev pdf2svg texlive texlive-science texlive-latex-recommended texlive-latex-extra
         python -m pip install --upgrade pip
         pip install -U pip wheel
-        pip install setuptools==45
         make install.dev install.base install.e
     - name: Format with [[ isort ]]
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-setuptools==45
 toolz
 colour
 svgwrite
 cairosvg
 Pillow
-planar
+git+https://github.com/srush/planar
 latextools
 loguru
 typing-extensions


### PR DESCRIPTION
People are reporting that Planar is not working on new versions of python. This is due to the C extension which is slow to install, and which we are note using anyway. This PR replaces the pip planar with a hosted one that just keeps the python code and removes the outdated element. 

This is not a good long term solution, but will come up with a better one later. 

